### PR TITLE
Allow to specify `libmagma` path via preferences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,8 @@ version = "0.1.0"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MAGMA_jll = "7a7c8717-d270-5a90-94a0-6104d6fc12ee"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
+Preferences = "1.4"
 julia = "1"

--- a/src/linearsolvers.jl
+++ b/src/linearsolvers.jl
@@ -2,7 +2,30 @@ module LibMagma
 # Write your package code here.
 using MAGMA_jll
 using CUDA
-const libmagma = MAGMA_jll.libmagma_path
+using Preferences
+
+const libmagma = begin
+    libmagma_pref = @load_preference("libmagma", nothing)
+    if !isnothing(libmagma_pref)
+        libmagma_pref
+    else
+        if MAGMA_jll.is_available()
+            MAGMA_jll.libmagma_path
+        else
+            @warn("""
+            MAGMA_jll isn't working. Will assume that a system libmagma is dynamically loadable.
+            To hide this warning, set the libmagma preference to a specific path
+            (e.g. with Magma.LibMagma.set_libmagma_path).
+            """)
+            "libmagma"
+        end
+    end
+end
+
+function set_libmagma_path(path::AbstractString)
+    @set_preferences!("libmagma" => path)
+    @info("New libmagma path set; please restart Julia to see this take effect", path)
+end
 
 export magma_init
 export magma_finalize


### PR DESCRIPTION
This PR adds support for a `libmagma` preference that can be used to explicitly specify a path to a local libmagma library (as an alternative to using the one provided via MAGMA_jll). The default doesn't change, that is, MAGMA_jll is used if no preference is specified.

Also, a `MAGMA_jll.is_available()` check is added. If it fails, e.g. when there is no product available for the host platform, a warning is thrown and `libmagma` is just set to `"libmagma"` (assuming that a local libmagma is dynamically loadable).